### PR TITLE
Update README with pre-commit hook usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,21 @@ SPDX-License-Identifier: CC0-1.0
 A CLI tool to check file encoding compliance. Supports UTF-8 by default and
 can validate against any Python-supported codec. Also lists all available
 encoding aliases. The tool aimed to be a `pre-commit` hook.
+
+## Using with `pre-commit`
+
+To check that every committed file is encoded in UTF-8 you can use
+`check-encoding` as a [`pre-commit`](https://pre-commit.com/) hook.  Add the
+following snippet to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/zaufi/check-encoding
+    rev: v0.1  # Use the appropriate released version
+    hooks:
+      - id: check-encoding
+        args: ["--encoding", "utf-8"]
+```
+
+After adding the configuration run `pre-commit install` once to activate the
+hook. It will then prevent commits that contain files not encoded in UTF-8.


### PR DESCRIPTION
## Summary
- document how to use `check-encoding` as a pre-commit hook

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686db2f82b3483238aa136e3e6685c5a