### PR TITLE
Use uv for Hatch installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ check-encoding = "check_encoding.cli:main"
 [tool.hatch.envs.default]
 description = "Development environment"
 dependencies = ["pytest"]
+installer = "uv"
 
 [tool.hatch.envs.default.scripts]
 test = "pytest"


### PR DESCRIPTION
## Summary
- revert CI workflow to use pip for installing Hatch
- configure Hatch to use `uv` for installing env dependencies

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686dce1782ec8323873ab647fda278f0