### PR TITLE
Remove sorting from list_encodings

### DIFF
--- a/check_encoding/cli.py
+++ b/check_encoding/cli.py
@@ -27,11 +27,11 @@ def list_encodings():
         lambda m, ai: m | {ai[1]: m.get(ai[1], []) + [ai[0]]}, aliases.items(), {}
     )
     canonical_to_aliases = {
-        canonical: [alias for alias in sorted(set(alist))]
+        canonical: list(dict.fromkeys(alist))
         for canonical, alist in canonical_to_aliases.items()
     }
 
-    for canonical, alias_list in sorted(canonical_to_aliases.items()):
+    for canonical, alias_list in canonical_to_aliases.items():
         print(f"{canonical.ljust(15)} (aliases: {', '.join(alias_list)})")
 
 


### PR DESCRIPTION
## Summary
- simplify list_encodings by removing unnecessary `sorted()` calls

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686de3b7c7e48323bb5a5d9c3af45aff